### PR TITLE
Add no_std support.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,6 @@ keywords = ["console", "terminal", "error"]
 categories = ["utils"]
 
 [dependencies]
+[features]
+std = []
+default = ["std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "highlight_error"
-version = "0.2.0"
+version = "0.1.2"
 edition = "2021"
 description = "Highlights an error for printing"
 repository = "https://github.com/VictorTaelin/rust_highlight_error"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "highlight_error"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 description = "Highlights an error for printing"
 repository = "https://github.com/VictorTaelin/rust_highlight_error"

--- a/src/highlight_error.rs
+++ b/src/highlight_error.rs
@@ -1,10 +1,12 @@
+use alloc::{format, string::String};
+
 /// Given a complete source file, highlights an error between two indexes (in bytes).
 pub fn highlight_error(ini_idx: usize, end_idx: usize, file: &str) -> String {
   // Please do NOT "improve" this by using high-order functions
 
   // Appends empty spaces to the left of a text
   fn pad(len: usize, txt: &str) -> String {
-    return format!("{}{}", " ".repeat(std::cmp::max(len - txt.len(), 0)), txt);
+    return format!("{}{}", " ".repeat(core::cmp::max(len - txt.len(), 0)), txt);
   }
 
   // Makes sure the end index is lower than the end index

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,10 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+//! Features:
+//! - `std`: enabled by default. Enables std support. When it is disabled, the crate is `no_std`.
+//! It will still need `alloc` though.
+
+extern crate alloc;
+
 mod highlight_error;
 
 pub use highlight_error::{*};

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,10 @@
+/// The "main" program can only be compiled
+/// with std.
+
+#![cfg(feature = "std")]
 #![allow(dead_code)]
+
+extern crate alloc;
 
 mod highlight_error;
 


### PR DESCRIPTION
`no_std` support is necessary for running crates that depend on this on embedded environments or in kernels. This adds a feature `std`, enabled by default, which enables std support. When `default-features = false` is used, it will be disabled and the crate will be `no_std`.