### PR TITLE
add no_std support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,7 @@ keywords = ["console", "terminal", "error"]
 categories = ["utils"]
 
 [dependencies]
+
+[features]
+default = ["std"]
+std = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "highlight_error"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "Highlights an error for printing"
 repository = "https://github.com/VictorTaelin/rust_highlight_error"

--- a/src/highlight_error.rs
+++ b/src/highlight_error.rs
@@ -1,10 +1,16 @@
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+
+#[cfg(not(feature = "std"))]
+pub use alloc::{format, string::String};
+
 /// Given a complete source file, highlights an error between two indexes (in bytes).
 pub fn highlight_error(ini_idx: usize, end_idx: usize, file: &str) -> String {
   // Please do NOT "improve" this by using high-order functions
 
   // Appends empty spaces to the left of a text
   fn pad(len: usize, txt: &str) -> String {
-    return format!("{}{}", " ".repeat(std::cmp::max(len - txt.len(), 0)), txt);
+    return format!("{}{}", " ".repeat(core::cmp::max(len - txt.len(), 0)), txt);
   }
 
   // Makes sure the end index is lower than the end index

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
 mod highlight_error;
 
 pub use highlight_error::{*};


### PR DESCRIPTION
Needed for `no_std` as part of no_std on [`TSPL`], which is needed for `no_std` support on [`hvm-core`].

Test with `cargo check` and `cargo check --no-default-features`.

[`TSPL`]: https://github.com/HigherOrderCO/TSPL
[`hvm-core`]: https://github.com/higherorderco/hvm-core