### PR TITLE
make no_std

### DIFF
--- a/src/highlight_error.rs
+++ b/src/highlight_error.rs
@@ -1,10 +1,12 @@
+use alloc::{string::String, format};
+
 /// Given a complete source file, highlights an error between two indexes (in bytes).
 pub fn highlight_error(ini_idx: usize, end_idx: usize, file: &str) -> String {
   // Please do NOT "improve" this by using high-order functions
 
   // Appends empty spaces to the left of a text
   fn pad(len: usize, txt: &str) -> String {
-    return format!("{}{}", " ".repeat(std::cmp::max(len - txt.len(), 0)), txt);
+    return format!("{}{}", " ".repeat(core::cmp::max(len - txt.len(), 0)), txt);
   }
 
   // Makes sure the end index is lower than the end index

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,7 @@
+#![no_std]
+
+extern crate alloc;
+
 mod highlight_error;
 
 pub use highlight_error::{*};

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,5 @@
 #![allow(dead_code)]
 
-mod highlight_error;
-
 fn main() {
   let code = "functon is_zero (x) {
     if (x == 0) [


### PR DESCRIPTION
Similar purpose as #2 and #4, but unconditionally enables `no_std`, as it doesn't ever need anything from `std`.